### PR TITLE
Don't return 'skip' from on_publish hook

### DIFF
--- a/src/mqtt/n2o_vnode.erl
+++ b/src/mqtt/n2o_vnode.erl
@@ -177,17 +177,20 @@ on_message_publish(#mqtt_message{topic = <<"events/", _TopicTail/binary>> = Topi
                 [E, V, '', M, U, _C, T] ->
                     {Mod, F} = application:get_env(n2o, vnode, {?MODULE, get_vnode}),
                     NewTopic = emqttd_topic:join([E, V, Mod:F(ClientId, Payload), M, U, ClientId, T]),
-                    emqttd:publish(emqttd_message:make(ClientId, Qos, NewTopic, Payload)), skip;
+                    NewMessage = emqttd_message:make(ClientId, Qos, NewTopic, Payload),
+                    {ok, NewMessage};
                 %% @NOTE redirect to vnode
                 [_E, _V, _N, _M, _U, ClientId, _T] -> {ok, Message};
                 [E, V, N, M, U, _C, T] ->
                     NewTopic = emqttd_topic:join([E, V, N, M, U, ClientId, T]),
-                    emqttd:publish(emqttd_message:make(ClientId, Qos, NewTopic, Payload)), skip;
+                    NewMessage = emqttd_message:make(ClientId, Qos, NewTopic, Payload),
+                    {ok, NewMessage};
                 %% @NOTE redirect to event topic with correct ClientId
                 _ -> {ok, Message}
             end;
-        _ -> skip end;
-on_message_publish(Message, _) -> {ok,Message}.
+        {error, ErrMessage} -> {ok, ErrMessage};
+        _ -> ok end;
+on_message_publish(_Message, _) -> ok.
 
 get_vnode(ClientId) -> get_vnode(ClientId, []).
 get_vnode(ClientId, _) ->


### PR DESCRIPTION
`emqttd_hooks` doesn't handle `skip` in any way, so the message won't
actually be skipped. See here:

https://github.com/NYNJA-MC/emqttd/blob/44352b2d4ea3fa0d41120c4310b149a0ca66a18a/src/emqttd_hooks.erl#L95-L105